### PR TITLE
compatibility with pomelo

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "peerDependencies" : {
         "pomelo-logger" : "0.1.6"
-    }
+    },
     "devDependencies": {
         "should": ">=0.0.1",
         "mocha": ">=0.0.1",


### PR DESCRIPTION
When use pomelo, pomelo-admin log is always empty because of pomelo-admin and pomelo dependent two pomelo-logger, and pomelo-admin uses a unconfigured pomelo-logger. Using npm's peer dependency can solve this problem, but it means that every app dependent pomelo-admin should write pomelo-logger dependent in their package.json.
